### PR TITLE
style: Formatting codes with clippy and fmt

### DIFF
--- a/os/src/console.rs
+++ b/os/src/console.rs
@@ -1,5 +1,5 @@
-use core::fmt::{self, Write};
 use crate::sbi::console_putchar;
+use core::fmt::{self, Write};
 
 struct Stdout;
 
@@ -29,5 +29,3 @@ macro_rules! println {
         $crate::console::print(format_args!(concat!($fmt, "\n") $(, $($arg)+)?));
     }
 }
-
-

--- a/os/src/lang_items.rs
+++ b/os/src/lang_items.rs
@@ -1,10 +1,15 @@
-use core::panic::PanicInfo;
 use crate::sbi::shutdown;
+use core::panic::PanicInfo;
 
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     if let Some(location) = info.location() {
-        println!("Panicked at {}:{} {}", location.file(), location.line(), info.message().unwrap());
+        println!(
+            "Panicked at {}:{} {}",
+            location.file(),
+            location.line(),
+            info.message().unwrap()
+        );
     } else {
         println!("Panicked: {}", info.message().unwrap());
     }

--- a/os/src/main.rs
+++ b/os/src/main.rs
@@ -9,7 +9,6 @@ mod console;
 mod lang_items;
 mod sbi;
 
-
 global_asm!(include_str!("entry.asm"));
 
 fn clear_bss() {
@@ -17,9 +16,7 @@ fn clear_bss() {
         fn sbss();
         fn ebss();
     }
-    (sbss as usize..ebss as usize).for_each(|a| {
-        unsafe { (a as *mut u8).write_volatile(0) }
-    });
+    (sbss as usize..ebss as usize).for_each(|a| unsafe { (a as *mut u8).write_volatile(0) });
 }
 
 #[no_mangle]
@@ -35,13 +32,16 @@ pub fn rust_main() -> ! {
         fn ebss();
         fn boot_stack();
         fn boot_stack_top();
-    };
+    }
     clear_bss();
     println!("Hello, world!");
     println!(".text [{:#x}, {:#x})", stext as usize, etext as usize);
     println!(".rodata [{:#x}, {:#x})", srodata as usize, erodata as usize);
     println!(".data [{:#x}, {:#x})", sdata as usize, edata as usize);
-    println!("boot_stack [{:#x}, {:#x})", boot_stack as usize, boot_stack_top as usize);
+    println!(
+        "boot_stack [{:#x}, {:#x})",
+        boot_stack as usize, boot_stack_top as usize
+    );
     println!(".bss [{:#x}, {:#x})", sbss as usize, ebss as usize);
     panic!("Shutdown machine!");
 }

--- a/os/src/sbi.rs
+++ b/os/src/sbi.rs
@@ -36,4 +36,3 @@ pub fn shutdown() -> ! {
     sbi_call(SBI_SHUTDOWN, 0, 0, 0);
     panic!("It should shutdown!");
 }
-


### PR DESCRIPTION
- Remove unnecessary trailing semicolon
- Exec `cargo fmt`