### PR TITLE
console: fix utf8 display

### DIFF
--- a/os/src/console.rs
+++ b/os/src/console.rs
@@ -5,8 +5,8 @@ struct Stdout;
 
 impl Write for Stdout {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        for c in s.chars() {
-            console_putchar(c as usize);
+        for c in s.bytes() {
+            console_putchar(c);
         }
         Ok(())
     }

--- a/os/src/main.rs
+++ b/os/src/main.rs
@@ -39,7 +39,7 @@ fn clear_bss() {
 #[no_mangle]
 pub fn rust_main() -> ! {
     clear_bss();
-    println!("[kernel] Hello, world!");
+    println!("[kernel] Hello, world! 你好世界！");
     mm::init();
     mm::remap_test();
     trap::init();

--- a/os/src/sbi.rs
+++ b/os/src/sbi.rs
@@ -28,8 +28,8 @@ pub fn set_timer(timer: usize) {
     sbi_call(SBI_SET_TIMER, timer, 0, 0);
 }
 
-pub fn console_putchar(c: usize) {
-    sbi_call(SBI_CONSOLE_PUTCHAR, c, 0, 0);
+pub fn console_putchar(c: u8) {
+    sbi_call(SBI_CONSOLE_PUTCHAR, c as usize, 0, 0);
 }
 
 pub fn console_getchar() -> usize {


### PR DESCRIPTION
**sbi putchar:**
```rust
#[inline]
pub fn console_putchar(param0: usize) -> SbiRet {
    let ch = (param0 & 0xff) as u8;
    legacy_stdio_putchar(ch);
    SbiRet::ok(0) // the return value 0 is ignored in legacy
}
```
It will cast param to u8, if param is utf8 value, the character will be broken.