### PR TITLE
移除const_in_array_repeat_expressions fix #4

### DIFF
--- a/os/src/main.rs
+++ b/os/src/main.rs
@@ -3,7 +3,6 @@
 #![feature(global_asm)]
 #![feature(llvm_asm)]
 #![feature(panic_info_message)]
-#![feature(const_in_array_repeat_expressions)]
 #![feature(alloc_error_handler)]
 
 extern crate alloc;


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/49147 根据rust-lang官方信息，该特性已在2月份被移除，编译时提示feature has been removed。移除该行后跑usertests，能正常跑完