### PR TITLE
fix: excute 'make run' failed on macos

### DIFF
--- a/os/Makefile
+++ b/os/Makefile
@@ -33,9 +33,9 @@ build: env switch-check $(KERNEL_BIN)
 
 switch-check:
 ifeq ($(BOARD), qemu)
-	(which last-qemu) || (rm last-k210 -f && touch last-qemu && make clean)
+	(which last-qemu) || (rm -f last-k210 && touch last-qemu && make clean)
 else ifeq ($(BOARD), k210)
-	(which last-k210) || (rm last-qemu -f && touch last-k210 && make clean)
+	(which last-k210) || (rm -f last-qemu && touch last-k210 && make clean)
 endif
 
 env:


### PR DESCRIPTION
OS: macOS 12.1

```
$ make run
rustup component add rust-src
info: component 'rust-src' is up to date
rustup component add llvm-tools-preview
info: component 'llvm-tools-preview' for target 'x86_64-apple-darwin' is up to date
cargo install cargo-binutils --vers =0.3.3
     Ignored package `cargo-binutils v0.3.3` is already installed, use --force to override
rustup target add riscv64gc-unknown-none-elf
info: component 'rust-std' for target 'riscv64gc-unknown-none-elf' is up to date
(which last-qemu) || (rm last-k210 -f && touch last-qemu && make clean)
rm: last-k210: No such file or directory
rm: -f: No such file or directory
make: *** [switch-check] Error 1
```