### PR TITLE
Fix: Add default goal

### DIFF
--- a/user/Makefile
+++ b/user/Makefile
@@ -6,6 +6,8 @@ APPS := $(wildcard $(APP_DIR)/*.rs)
 ELFS := $(patsubst $(APP_DIR)/%.rs, $(TARGET_DIR)/%, $(APPS))
 BINS := $(patsubst $(APP_DIR)/%.rs, $(TARGET_DIR)/%.bin, $(APPS))
 
+default: build
+
 OBJDUMP := rust-objdump --arch-name=riscv64
 OBJCOPY := rust-objcopy --binary-architecture=riscv64
 


### PR DESCRIPTION
make 之后发现虽然有信息：target/riscv64gc-unknown-none-elf/release/hello.bin 但并未产生此文件。故增加默认 goal