### PR TITLE
virtaddr -> usize high 256GB addrspace bug fix

### DIFF
--- a/os/src/mm/address.rs
+++ b/os/src/mm/address.rs
@@ -83,7 +83,11 @@ impl From<PhysPageNum> for usize {
 }
 impl From<VirtAddr> for usize {
     fn from(v: VirtAddr) -> Self {
-        v.0
+        if v.0 >= (1 << (VA_WIDTH_SV39 - 1)) {
+            v.0 | (!((1 << VA_WIDTH_SV39) - 1))
+        } else {
+            v.0
+        }
     }
 }
 impl From<VirtPageNum> for usize {


### PR DESCRIPTION
I think high 256GB virtual address for SV39 mode converting to usize should be discussed separately