### PR TITLE
fix(BlockCache): Vec as aligned buf

### DIFF
--- a/easy-fs/src/block_cache.rs
+++ b/easy-fs/src/block_cache.rs
@@ -1,11 +1,13 @@
 use super::{BlockDevice, BLOCK_SZ};
 use alloc::collections::VecDeque;
 use alloc::sync::Arc;
+use alloc::vec;
+use alloc::vec::Vec;
 use lazy_static::*;
 use spin::Mutex;
 
 pub struct BlockCache {
-    cache: [u8; BLOCK_SZ],
+    cache: Vec<u8>,
     block_id: usize,
     block_device: Arc<dyn BlockDevice>,
     modified: bool,
@@ -14,7 +16,8 @@ pub struct BlockCache {
 impl BlockCache {
     /// Load a new BlockCache from disk.
     pub fn new(block_id: usize, block_device: Arc<dyn BlockDevice>) -> Self {
-        let mut cache = [0u8; BLOCK_SZ];
+        // for alignment and move effciency
+        let mut cache = vec![0u8; BLOCK_SZ];
         block_device.read_block(block_id, &mut cache);
         Self {
             cache,


### PR DESCRIPTION
use a `Vec` allocated from buddy system to make sure it's at least 512 bytes aligned, so that the `buf` passed to `VirtIOBlock::read_block` does not across any two physical pages.
And it's more efficient since you do not need to move the 512B buf when creating `Arc<Mutex<BlockCache>>`
More detailed info at [here](https://github.com/rcore-os/virtio-drivers/issues/8).