### PR TITLE
fix(page_table): ref at page boundary

### DIFF
--- a/os/src/mm/mod.rs
+++ b/os/src/mm/mod.rs
@@ -11,7 +11,7 @@ pub use memory_set::remap_test;
 pub use memory_set::{kernel_token, MapPermission, MemorySet, KERNEL_SPACE};
 use page_table::PTEFlags;
 pub use page_table::{
-    translated_byte_buffer, translated_ref, translated_refmut, translated_str, PageTable,
+    translated_byte_buffer, translated_refmut, translated_str, translated_value, PageTable,
     PageTableEntry, UserBuffer, UserBufferIterator,
 };
 

--- a/os/src/syscall/fs.rs
+++ b/os/src/syscall/fs.rs
@@ -79,8 +79,8 @@ pub fn sys_pipe(pipe: *mut usize) -> isize {
     inner.fd_table[read_fd] = Some(pipe_read);
     let write_fd = inner.alloc_fd();
     inner.fd_table[write_fd] = Some(pipe_write);
-    *translated_refmut(token, pipe) = read_fd;
-    *translated_refmut(token, unsafe { pipe.add(1) }) = write_fd;
+    translated_refmut(token, pipe).write(read_fd);
+    translated_refmut(token, unsafe { pipe.add(1) }).write(write_fd);
     0
 }
 


### PR DESCRIPTION
In **page_table.rs**, `translated_byte_buffer` do `translate` for each physical page and `translated_str` do `translate_va` for each address, but `translated_ref` and `translated_refmut` did not do anything to make sure the **va -> pa** mapping is always correct.
The right way to do it is treating variables just like buffers.
For example, if a variable of 8 bytes is on virtual address of **[0xffc, 0x1004)**, it will cross the page boundry, and when these two virtual pages is **NOT smoothly mapped** in physical memory (just like what happened on `VirtIOBlock::read_block`), it could cause a page fault or reading/writing garbage data when trying to access the last 4 bytes since the translation happened only once at start virtual address.
I changed the `translated_ref` to `translated_value` since there has to be a buffer when translating so a ref of value could not do it correctly or save any space & time.
Also modified `translated_refmut` to return a proxy class of `UserBuffer`, I was trying to make it work just like `&mut`, but Rust could not overload the `=` operator, donno if there's better practice.
Still **NOT SURE** that all of this is correct and necessary, please tell me if I was missing something.