### PR TITLE
ch5 code error

### DIFF
--- a/os/src/syscall/fs.rs
+++ b/os/src/syscall/fs.rs
@@ -28,7 +28,7 @@ pub fn sys_read(fd: usize, buf: *const u8, len: usize) -> isize {
             let mut c: usize;
             loop {
                 c = console_getchar();
-                if c == 0 {
+                if c == usize::MAX {
                     suspend_current_and_run_next();
                     continue;
                 } else {


### PR DESCRIPTION
When I'm doing the experment of ch5, the user_shell will run out of heap space. I find the cause is that sbi_return_value -1 means error instead of 0. I change 0 to usize::MAX, and then os can run normally.