### PR TITLE
rename link file's name to pass compile

### DIFF
--- a/os/.cargo/config
+++ b/os/.cargo/config
@@ -3,5 +3,5 @@ target = "riscv64gc-unknown-none-elf"
 
 [target.riscv64gc-unknown-none-elf]
 rustflags = [
-    "-Clink-arg=-Tsrc/linker.ld", "-Cforce-frame-pointers=yes"
+    "-Clink-arg=-Tsrc/linker-qemu.ld", "-Cforce-frame-pointers=yes"
 ]


### PR DESCRIPTION
The actual linker script filename is not correspond to the one in the cargo's config file.