### PR TITLE
feat: support devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "rcore-tutorial-v3",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "args": {
+      "QEMU_VERSION": "7.0.0",
+      "DEBIAN_FRONTEND": "noninteractive",
+      "GDB_VERSION": "14.1"
+    }
+  },
+  "postCreateCommand": "rustup show",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "ms-vscode.cpptools",
+        "tamasfe.even-better-toml"
+      ]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .*/*
 !.github/*
 !.vscode/settings.json
+!.devcontainer/devcontainer.json
 
 **/target/
 **/Cargo.lock

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,6 @@
 [toolchain]
 profile = "minimal"
 # use the nightly version of the last stable toolchain, see <https://forge.rust-lang.org/>
-channel = "nightly-2023-10-09"
+channel = "nightly-2024-01-18"
 components = ["rust-src", "llvm-tools-preview", "rustfmt", "clippy"]
+targets = ["riscv64gc-unknown-none-elf"]


### PR DESCRIPTION
- Add devcontainer support to use the development environment directly via vscode or codespaces.
- Channel `nightly-2023-10-09` did not successfully compile `clippy-aarch64-unknown-linux-gnu`, causing it to not run on arm64 machines.