### PR TITLE
Rewrite Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 */*
+!rust-toolchain.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ FROM ubuntu:20.04 as build_qemu
 ARG QEMU_VERSION=7.0.0
 
 RUN sed -i 's/archive.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list && \ 
+    sed -i 's/security.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list && \ 
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y wget build-essential libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev ninja-build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,85 +1,63 @@
 # syntax=docker/dockerfile:1
-# This Dockerfile is adapted from https://github.com/LearningOS/rCore-Tutorial-v3/blob/main/Dockerfile
-# with the following major updates:
-# - ubuntu 18.04 -> 20.04
-# - qemu 5.0.0 -> 7.0.0
-# - Extensive comments linking to relevant documentation
-FROM ubuntu:20.04
+
+# Stage 1 Set up QEMU RISC-V
+# - https://www.qemu.org/download/
+# - https://wiki.qemu.org/Hosts/Linux#Building_QEMU_for_Linux
+# - https://wiki.qemu.org/Documentation/Platforms/RISCV
+
+FROM ubuntu:20.04 as build_qemu
 
 ARG QEMU_VERSION=7.0.0
-ARG HOME=/root
 
-# 0. Install general tools
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && \
-    apt-get install -y \
-        curl \
-        git \
-        python3 \
-        wget
+RUN sed -i 's/archive.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list && \ 
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y wget build-essential libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev ninja-build
 
-# 1. Set up QEMU RISC-V
-# - https://learningos.github.io/rust-based-os-comp2022/0setup-devel-env.html#qemu
-# - https://www.qemu.org/download/
-# - https://wiki.qemu.org/Documentation/Platforms/RISCV
-# - https://risc-v-getting-started-guide.readthedocs.io/en/latest/linux-qemu.html
-
-# 1.1. Download source
-WORKDIR ${HOME}
 RUN wget https://download.qemu.org/qemu-${QEMU_VERSION}.tar.xz && \
-    tar xvJf qemu-${QEMU_VERSION}.tar.xz
-
-# 1.2. Install dependencies
-# - https://risc-v-getting-started-guide.readthedocs.io/en/latest/linux-qemu.html#prerequisites
-RUN apt-get install -y \
-        autoconf automake autotools-dev curl libmpc-dev libmpfr-dev libgmp-dev \
-        gawk build-essential bison flex texinfo gperf libtool patchutils bc \
-        zlib1g-dev libexpat-dev git \
-        ninja-build pkg-config libglib2.0-dev libpixman-1-dev libsdl2-dev
-
-# 1.3. Build and install from source
-WORKDIR ${HOME}/qemu-${QEMU_VERSION}
-RUN ./configure --target-list=riscv64-softmmu,riscv64-linux-user && \
+    tar xf qemu-${QEMU_VERSION}.tar.xz && \
+    cd qemu-${QEMU_VERSION} && \ 
+    ./configure --target-list=riscv64-softmmu,riscv64-linux-user && \
     make -j$(nproc) && \
     make install
 
-# 1.4. Clean up
-WORKDIR ${HOME}
-RUN rm -rf qemu-${QEMU_VERSION} qemu-${QEMU_VERSION}.tar.xz
+# Stage 2 Lab Environment
+FROM ubuntu:20.04 as build
 
-# 1.5. Sanity checking
-RUN qemu-system-riscv64 --version && \
-    qemu-riscv64 --version
+WORKDIR /tmp
 
-# 2. Set up Rust
-# - https://learningos.github.io/rust-based-os-comp2022/0setup-devel-env.html#qemu
+# 0. Install general tools
+RUN sed -i 's/archive.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list && \ 
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y jq curl git python3 wget build-essential \
+    # qemu dependency
+    libglib2.0-0 libfdt1 libpixman-1-0 zlib1g
+
+# 1. Copy qemu
+COPY --from=build_qemu /usr/local/bin/* /usr/local/bin
+
+# 2. Install Rust
 # - https://www.rust-lang.org/tools/install
-# - https://github.com/rust-lang/docker-rust/blob/master/Dockerfile-debian.template
-
-# 2.1. Install
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=nightly
-RUN set -eux; \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init; \
-    chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION; \
-    rm rustup-init; \
-    chmod -R a+w $RUSTUP_HOME $CARGO_HOME;
-
-# 2.2. Sanity checking
-RUN rustup --version && \
-    cargo --version && \
-    rustc --version
+    PATH=/usr/local/cargo/bin:$PATH
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --no-modify-path --profile minimal --default-toolchain nightly
 
 # 3. Build env for labs
-# See os1/Makefile `env:` for example.
+# See os/Makefile `env:` for example.
 # This avoids having to wait for these steps each time using a new container.
+COPY rust-toolchain.toml rust-toolchain.toml
 RUN rustup target add riscv64gc-unknown-none-elf && \
-    cargo install cargo-binutils --vers ~0.2 && \
-    rustup component add rust-src && \
-    rustup component add llvm-tools-preview
+    cargo install toml-cli cargo-binutils && \
+    RUST_VERSION=$(toml get -r rust-toolchain.toml toolchain.channel) && \
+    Components=$(toml get -r rust-toolchain.toml toolchain.components | jq -r 'join(" ")') && \
+    rustup install $RUST_VERSION && \
+    rustup component add --toolchain $RUST_VERSION $Components
 
-# Ready to go
-WORKDIR ${HOME}
+# Stage 3 Sanity checking
+FROM build as test
+RUN qemu-system-riscv64 --version && \
+    qemu-riscv64 --version && \
+    rustup --version && \
+    cargo --version && \
+    rustc --version

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
-DOCKER_NAME ?= rcore-tutorial-v3
+DOCKER_TAG ?= rcore-tutorial-v3:latest
 .PHONY: docker build_docker
 	
 docker:
-	docker run --rm -it -v ${PWD}:/mnt -w /mnt ${DOCKER_NAME} bash
+	docker run --rm -it -v ${PWD}:/mnt -w /mnt --name rcore-tutorial-v3 ${DOCKER_TAG} bash
 
 build_docker: 
-	docker build -t ${DOCKER_NAME} .
+	docker build -t ${DOCKER_TAG} --target build .
 
 fmt:
 	cd easy-fs; cargo fmt; cd ../easy-fs-fuse cargo fmt; cd ../os ; cargo fmt; cd ../user; cargo fmt; cd ..

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 profile = "minimal"
 # use the nightly version of the last stable toolchain, see <https://forge.rust-lang.org/>
 channel = "nightly-2023-10-09"
-components = ["rust-src", "llvm-tools-preview", "rustfmt", "clippy"]
+components = ["rust-src", "llvm-tools", "rustfmt", "clippy"]


### PR DESCRIPTION
#138 

- Use multi-stage building, significantly reducing the image size. (3.56GB -> 2.06GB)
- Use mirrors.tuna.tsinghua.edu.cn to accelerate the fetching of software packages.
- Simplify the installation process of Rust.
- Fixed an issue where the experimental environment could not be correctly pre-set due to differences between the 'nightly' and 'nightly-2023-10-09' versions. Now it can dynamically adapt to the current Rust version based on rust-toolchain.toml.
- Add a test stage for image building.
- Clean up some invalid or irrelevant documentation links.

The image built by the new Dockerfile has been tested by 
```shell
cd os
make run

···

**************/
Rust user shell
>> usertests

···

34 of sueecssed apps, 9 of failed apps run correctly. 
Usertests passed!
```
and the results remain the same as before.