### PR TITLE
fix: linker script "linker.ld" not found, using "linker-qemu.ld" in .cargo/config.toml instead.

### DIFF
--- a/os/.cargo/config.toml
+++ b/os/.cargo/config.toml
@@ -3,5 +3,5 @@ target = "riscv64gc-unknown-none-elf"
 
 [target.riscv64gc-unknown-none-elf]
 rustflags = [
-    "-Clink-arg=-Tsrc/linker.ld", "-Cforce-frame-pointers=yes"
+    "-Clink-arg=-Tsrc/linker-qemu.ld", "-Cforce-frame-pointers=yes"
 ]


### PR DESCRIPTION
Fail to run `cargo build` in ch1, rustc fail to found "linker.ld" according to "os/.cargo/config.toml". Using "linker-qemu.ld" instead.