### PR TITLE
Fix docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN sed -i 's/archive.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/source
     gdb-multiarch
 
 # 2.1. Copy qemu
-COPY --from=build_qemu /usr/local/bin/* /usr/local/bin
+COPY --from=build_qemu /usr/local/bin/* /usr/local/bin/
 
 # 2.2. Install Rust
 # - https://www.rust-lang.org/tools/install


### PR DESCRIPTION
error when I run `make build_docker`:
```
Step 8/13 : COPY --from=build_qemu /usr/local/bin/* /usr/local/bin
When using COPY with more than one source file, the destination must be a directory and end with a /
make: *** [Makefile:8: build_docker] Error 1
```
docker version:
```
docker --version
Docker version 27.1.1, build 63125853e3
```
Adding `/` after `/usr/local/bin` fixes it.