### PR TITLE
fix alignment of cache

### DIFF
--- a/easy-fs/src/block_cache.rs
+++ b/easy-fs/src/block_cache.rs
@@ -1,3 +1,6 @@
+use core::ptr::{addr_of, addr_of_mut};
+use core::slice;
+
 use super::{BlockDevice, BLOCK_SZ};
 use alloc::collections::VecDeque;
 use alloc::sync::Arc;
@@ -6,8 +9,31 @@ use alloc::vec::Vec;
 use lazy_static::*;
 use spin::Mutex;
 
+/// use `Vec<u64>` to ensure the alignment of addr is `8`
+struct CacheData(Vec<u64>);
+
+impl CacheData {
+    fn new() -> Self {
+        Self(vec![0u64; BLOCK_SZ / 8])
+    }
+}
+
+impl AsRef<[u8]> for CacheData {
+    fn as_ref(&self) -> &[u8] {
+        let ptr = self.0.as_ptr() as *const u8;
+        unsafe { slice::from_raw_parts(ptr, BLOCK_SZ) }
+    }
+}
+
+impl AsMut<[u8]> for CacheData {
+    fn as_mut(&mut self) -> &mut [u8] {
+        let ptr = self.0.as_mut_ptr() as *mut u8;
+        unsafe { slice::from_raw_parts_mut(ptr, BLOCK_SZ) }
+    }
+}
+
 pub struct BlockCache {
-    cache: Vec<u8>,
+    cache: CacheData,
     block_id: usize,
     block_device: Arc<dyn BlockDevice>,
     modified: bool,
@@ -17,8 +43,8 @@ impl BlockCache {
     /// Load a new BlockCache from disk.
     pub fn new(block_id: usize, block_device: Arc<dyn BlockDevice>) -> Self {
         // for alignment and move effciency
-        let mut cache = vec![0u8; BLOCK_SZ];
-        block_device.read_block(block_id, &mut cache);
+        let mut cache = CacheData::new();
+        block_device.read_block(block_id, cache.as_mut());
         Self {
             cache,
             block_id,
@@ -27,8 +53,12 @@ impl BlockCache {
         }
     }
 
-    fn addr_of_offset(&self, offset: usize) -> usize {
-        &self.cache[offset] as *const _ as usize
+    fn addr_of_offset(&self, offset: usize) -> *const u8 {
+        addr_of!(self.cache.as_ref()[offset])
+    }
+
+    fn addr_of_offset_mut(&mut self, offset: usize) -> *mut u8 {
+        addr_of_mut!(self.cache.as_mut()[offset])
     }
 
     pub fn get_ref<T>(&self, offset: usize) -> &T
@@ -37,8 +67,8 @@ impl BlockCache {
     {
         let type_size = core::mem::size_of::<T>();
         assert!(offset + type_size <= BLOCK_SZ);
-        let addr = self.addr_of_offset(offset);
-        unsafe { &*(addr as *const T) }
+        let addr = self.addr_of_offset(offset) as *const T;
+        unsafe { &*addr }
     }
 
     pub fn get_mut<T>(&mut self, offset: usize) -> &mut T
@@ -48,8 +78,8 @@ impl BlockCache {
         let type_size = core::mem::size_of::<T>();
         assert!(offset + type_size <= BLOCK_SZ);
         self.modified = true;
-        let addr = self.addr_of_offset(offset);
-        unsafe { &mut *(addr as *mut T) }
+        let addr = self.addr_of_offset_mut(offset) as *mut T;
+        unsafe { &mut *addr }
     }
 
     pub fn read<T, V>(&self, offset: usize, f: impl FnOnce(&T) -> V) -> V {
@@ -63,7 +93,8 @@ impl BlockCache {
     pub fn sync(&mut self) {
         if self.modified {
             self.modified = false;
-            self.block_device.write_block(self.block_id, &self.cache);
+            self.block_device
+                .write_block(self.block_id, self.cache.as_ref());
         }
     }
 }


### PR DESCRIPTION
1. define `CacheData` to replace raw `Vec<u8>`.
`Vec<T>` prove that the alignment of inner data satisfy the align requirement of `T`, so alignment of `Vec<u64>` will be `8`, and alignment of `Vec<u8>` will be `1`.
If we alloc `Vec<u8>` directly, then reinterpret the inner memory into a struct of alignment of `8`, such as `BitmapBlock`, will cause [undefined behavior](https://doc.rust-lang.org/reference/behavior-considered-undefined.html#places-based-on-misaligned-pointers).
2. following [strict provenance](https://doc.rust-lang.org/std/ptr/index.html#strict-provenance), `addr_of_offset` now return pointer instead of `usize`.
`&raw` syntax is not stabled in project's toolchain, `addr_of!` macro could be removed if the toolchain is updated in the future.