### PR TITLE
replacing VPNRange

### DIFF
--- a/os/src/drivers/bus/virtio.rs
+++ b/os/src/drivers/bus/virtio.rs
@@ -1,6 +1,6 @@
 use crate::mm::{
     frame_alloc_more, frame_dealloc, kernel_token, FrameTracker, PageTable, PhysAddr, PhysPageNum,
-    StepByOne, VirtAddr,
+    VirtAddr,
 };
 use crate::sync::UPIntrFreeCell;
 use alloc::vec::Vec;
@@ -30,7 +30,7 @@ impl Hal for VirtioHal {
         let mut ppn_base: PhysPageNum = pa.into();
         for _ in 0..pages {
             frame_dealloc(ppn_base);
-            ppn_base.step();
+            ppn_base = core::iter::Step::forward(ppn_base, 1);
         }
         0
     }

--- a/os/src/main.rs
+++ b/os/src/main.rs
@@ -1,5 +1,7 @@
 #![no_std]
 #![no_main]
+#![feature(step_trait)]
+#![feature(new_range_api)]
 #![feature(panic_info_message)]
 #![feature(alloc_error_handler)]
 

--- a/os/src/mm/address.rs
+++ b/os/src/mm/address.rs
@@ -190,81 +190,34 @@ impl PhysPageNum {
     }
 }
 
-pub trait StepByOne {
-    fn step(&mut self);
-}
-impl StepByOne for VirtPageNum {
-    fn step(&mut self) {
-        self.0 += 1;
+impl core::iter::Step for VirtPageNum {
+    fn steps_between(start: &Self, end: &Self) -> (usize, Option<usize>) {
+        (end.0 - start.0, Some(end.0 - start.0))
     }
-}
-impl StepByOne for PhysPageNum {
-    fn step(&mut self) {
-        self.0 += 1;
+
+    fn forward_checked(mut start: Self, count: usize) -> Option<Self> {
+        start.0 = start.0.checked_add(count)?;
+        Some(start)
+    }
+
+    fn backward_checked(mut start: Self, count: usize) -> Option<Self> {
+        start.0 = start.0.checked_sub(count)?;
+        Some(start)
     }
 }
 
-#[derive(Copy, Clone)]
-pub struct SimpleRange<T>
-where
-    T: StepByOne + Copy + PartialEq + PartialOrd + Debug,
-{
-    l: T,
-    r: T,
-}
-impl<T> SimpleRange<T>
-where
-    T: StepByOne + Copy + PartialEq + PartialOrd + Debug,
-{
-    pub fn new(start: T, end: T) -> Self {
-        assert!(start <= end, "start {:?} > end {:?}!", start, end);
-        Self { l: start, r: end }
+impl core::iter::Step for PhysPageNum {
+    fn steps_between(start: &Self, end: &Self) -> (usize, Option<usize>) {
+        (end.0 - start.0, Some(end.0 - start.0))
     }
-    pub fn get_start(&self) -> T {
-        self.l
+
+    fn forward_checked(mut start: Self, count: usize) -> Option<Self> {
+        start.0 = start.0.checked_add(count)?;
+        Some(start)
     }
-    pub fn get_end(&self) -> T {
-        self.r
+
+    fn backward_checked(mut start: Self, count: usize) -> Option<Self> {
+        start.0 = start.0.checked_sub(count)?;
+        Some(start)
     }
 }
-impl<T> IntoIterator for SimpleRange<T>
-where
-    T: StepByOne + Copy + PartialEq + PartialOrd + Debug,
-{
-    type Item = T;
-    type IntoIter = SimpleRangeIterator<T>;
-    fn into_iter(self) -> Self::IntoIter {
-        SimpleRangeIterator::new(self.l, self.r)
-    }
-}
-pub struct SimpleRangeIterator<T>
-where
-    T: StepByOne + Copy + PartialEq + PartialOrd + Debug,
-{
-    current: T,
-    end: T,
-}
-impl<T> SimpleRangeIterator<T>
-where
-    T: StepByOne + Copy + PartialEq + PartialOrd + Debug,
-{
-    pub fn new(l: T, r: T) -> Self {
-        Self { current: l, end: r }
-    }
-}
-impl<T> Iterator for SimpleRangeIterator<T>
-where
-    T: StepByOne + Copy + PartialEq + PartialOrd + Debug,
-{
-    type Item = T;
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.current == self.end {
-            None
-        } else {
-            let t = self.current;
-            self.current.step();
-            Some(t)
-        }
-    }
-}
-pub type VPNRange = SimpleRange<VirtPageNum>;

--- a/os/src/mm/mod.rs
+++ b/os/src/mm/mod.rs
@@ -4,8 +4,7 @@ mod heap_allocator;
 mod memory_set;
 mod page_table;
 
-pub use address::VPNRange;
-pub use address::{PhysAddr, PhysPageNum, StepByOne, VirtAddr, VirtPageNum};
+pub use address::{PhysAddr, PhysPageNum, VirtAddr, VirtPageNum};
 pub use frame_allocator::{frame_alloc, frame_alloc_more, frame_dealloc, FrameTracker};
 pub use memory_set::{kernel_token, MapArea, MapPermission, MapType, MemorySet, KERNEL_SPACE};
 use page_table::PTEFlags;

--- a/os/src/mm/page_table.rs
+++ b/os/src/mm/page_table.rs
@@ -1,4 +1,4 @@
-use super::{frame_alloc, FrameTracker, PhysAddr, PhysPageNum, StepByOne, VirtAddr, VirtPageNum};
+use super::{frame_alloc, FrameTracker, PhysAddr, PhysPageNum, VirtAddr, VirtPageNum};
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -146,7 +146,7 @@ pub fn translated_byte_buffer(token: usize, ptr: *const u8, len: usize) -> Vec<&
         let start_va = VirtAddr::from(start);
         let mut vpn = start_va.floor();
         let ppn = page_table.translate(vpn).unwrap().ppn();
-        vpn.step();
+        vpn = core::iter::Step::forward(vpn, 1);
         let mut end_va: VirtAddr = vpn.into();
         end_va = end_va.min(VirtAddr::from(end));
         if end_va.page_offset() == 0 {


### PR DESCRIPTION
impl `Step` trait for `VirtPageNum`.

Use `core::range::Range<VirtPageNum>` replacing  `VPNRange = SimpleRange<VirtPageNum>`

This will enable feature [step_trait](https://github.com/rust-lang/rust/issues/42168) 和 [new_range_api](https://github.com/rust-lang/rust/issues/125687)  